### PR TITLE
Update github-changelog-lib to 0.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,6 @@ dependencies {
     testCompile 'com.github.stefanbirkner:system-rules:1.18.0'
     testCompile "org.ajoberstar:gradle-git:1.7.2"
     testCompile 'com.wooga.spock.extensions:spock-github-extension:0.1.0'
-    compile 'com.wooga.github:github-changelog-lib:0.1.1'
+    compile 'com.wooga.github:github-changelog-lib:0.1.2'
     compile "gradle.plugin.net.wooga.gradle:atlas-github:1.+"
 }


### PR DESCRIPTION
## Description

Update because of a bug in [`com.wooga.github:github-changelog-lib`]

[`com.wooga.github:github-changelog-lib`]: https://github.com/wooga/github-changelog-lib/pull/2

## Changes

* ![UPDATE] `com.wooga.github:github-changelog-lib` to `0.1.2`

[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"