### PR TITLE
Update github-changelog-lib to 0.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,6 @@ dependencies {
     testCompile 'com.github.stefanbirkner:system-rules:1.18.0'
     testCompile "org.ajoberstar:gradle-git:1.7.2"
     testCompile 'com.wooga.spock.extensions:spock-github-extension:0.1.0'
-    compile 'com.wooga.github:github-changelog-lib:0.2.+'
+    compile 'com.wooga.github:github-changelog-lib:0.3.+'
     compile "gradle.plugin.net.wooga.gradle:atlas-github:1.+"
 }


### PR DESCRIPTION
## Description

This update brings minor validation changes and better error messages.

## Changes

* ![UPDATE] `github-changelog-lib` to `0.3.0`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"