### PR TITLE
Update github-changelog-lib to 0.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,6 @@ dependencies {
     testCompile 'com.github.stefanbirkner:system-rules:1.18.0'
     testCompile "org.ajoberstar:gradle-git:1.7.2"
     testCompile 'com.wooga.spock.extensions:spock-github-extension:0.1.0'
-    compile 'com.wooga.github:github-changelog-lib:0.3.+'
+    compile 'com.wooga.github:github-changelog-lib:0.4.+'
     compile "gradle.plugin.net.wooga.gradle:atlas-github:1.+"
 }

--- a/src/main/groovy/wooga/gradle/githubReleaseNotes/tasks/GenerateReleaseNotes.groovy
+++ b/src/main/groovy/wooga/gradle/githubReleaseNotes/tasks/GenerateReleaseNotes.groovy
@@ -58,7 +58,7 @@ class GenerateReleaseNotes extends AbstractGithubTask {
         def outputFile = output.get().asFile
         outputFile.parentFile.mkdirs()
         def s = strategy.get()
-        def rawChanges = detector.detectChangesFromTag(
+        def rawChanges = detector.detectChanges(
                 from.getOrNull() as String,
                 to.getOrNull() as String,
                 branch.get())


### PR DESCRIPTION
## Description

This patch updates the dependency of [github-changelog-lib] to version `0.4.0`. This change allows also to use a more generic API `detectChanges` which can work with any `String` value for `from` and `to` that can be converted into a commit object. See the change [here][github-changelog-lib-pr]

## Changes

* ![UPDATE] [github-changelog-lib] to `0.4.0`
* ![IMPROVE] use new generic API call `detectChanges`

[github-changelog-lib]: https://github.com/wooga/github-changelog-lib
[github-changelog-lib-pr]: https://github.com/wooga/github-changelog-lib/pull/7

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:http://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[UNITY]:http://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"