### PR TITLE
updated spock-github-extension version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,12 +43,12 @@ pluginBundle {
 }
 
 github {
-    repositoryName = "wooga/atlas-github-release-notes"
+    repositoryName.value "wooga/atlas-github-release-notes"
 }
 
 dependencies {
     testCompile "org.ajoberstar:grgit:1.7.2"
-    testCompile'com.wooga.spock.extensions:spock-github-extension:0.1.2'
+    testCompile'com.wooga.spock.extensions:spock-github-extension:[0.1.2, 0.2)'
     compile 'com.wooga.github:github-changelog-lib:[0.4.2, 0.5)'
     compile "gradle.plugin.net.wooga.gradle:atlas-github:[2,3)"
 }


### PR DESCRIPTION
## Description 
This PR is being made in order to test the release notes function embed in the new version of the plugin.

## Changes
  * ![UPDATE] updated `spock-github-extension`  version descriptor
  
 [UPDATE]: https://resources.atlas.wooga.com/icons/icon_update.svg
