### PR TITLE
Refactor properties in task to use getters

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -20,4 +20,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip

--- a/src/main/groovy/wooga/gradle/githubReleaseNotes/tasks/GenerateReleaseNotes.groovy
+++ b/src/main/groovy/wooga/gradle/githubReleaseNotes/tasks/GenerateReleaseNotes.groovy
@@ -12,33 +12,61 @@ import org.gradle.api.tasks.TaskAction
 import wooga.gradle.github.base.tasks.internal.AbstractGithubTask
 
 class GenerateReleaseNotes extends AbstractGithubTask {
+
+    private final Property<String> releaseName
+
     @Input
-    final Property<String> releaseName
+    Property<String> getReleaseName() {
+        releaseName
+    }
+
+    private final Property<String> from
 
     @Input
     @Optional
-    final Property<String> from
+    Property<String> getFrom() {
+        from
+    }
+
+    private final Property<String> to
 
     @Input
     @Optional
-    final Property<String> to
+    Property<String> getTo() {
+        to
+    }
+
+    private final Property<String> branch
 
     @Input
-    final Property<String> branch
+    Property<String> getBranch() {
+        branch
+    }
+
+    private final Property<GeneratorStrategy> strategy
 
     @Input
-    final Property<GeneratorStrategy> strategy
+    Property<GeneratorStrategy> getStrategy() {
+        strategy
+    }
 
-    @Optional
+    private final Property<Closure<String>> renderer
+
     @Internal
-    final Property<Closure<String>> renderer
+    Property<Closure<String>> getRenderer() {
+        renderer
+    }
 
     void setRenderer(Closure<String> renderer) {
         this.renderer.set(renderer)
     }
 
+    private final RegularFileProperty output
+
     @OutputFile
-    final RegularFileProperty output
+    RegularFileProperty getOutput() {
+        output
+    }
 
     GenerateReleaseNotes() {
         super(GenerateReleaseNotes.class)
@@ -47,7 +75,7 @@ class GenerateReleaseNotes extends AbstractGithubTask {
         to = this.project.objects.property(String)
         releaseName = this.project.objects.property(String)
         branch = this.project.objects.property(String)
-        branch.set(this.project.provider({this.repository.defaultBranch}))
+        branch.set(this.project.provider({ this.repository.defaultBranch }))
         strategy = this.project.objects.property(GeneratorStrategy)
         renderer = this.project.objects.property(Closure) as Property<Closure>
     }
@@ -69,8 +97,7 @@ class GenerateReleaseNotes extends AbstractGithubTask {
             def renderer = this.renderer.get()
             def changeSet = s.mapChangeSet(rawChanges)
             outputFile.text = renderer.call(changeSet)
-        }
-        else {
+        } else {
             outputFile.text = s.render(rawChanges)
         }
     }


### PR DESCRIPTION
Refactors properties to use getters to avoid deprecation warnings.

In a downstream project, the following errors are emitted:

```console
Deprecation warnings were found (Set the ignoreDeprecations system property during the test to ignore):
 - Property 'renderer' annotated with @Internal should not be also annotated with @Optional. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.9/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
 - Property 'client' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.9/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
 - Property 'repository' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.9/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
java.lang.IllegalArgumentException: Deprecation warnings were found (Set the ignoreDeprecations system property during the test to ignore):
 - Property 'renderer' annotated with @Internal should not be also annotated with @Optional. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.9/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
 - Property 'client' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.9/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
 - Property 'repository' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.9/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
	at nebula.test.IntegrationBase$Trait$Helper.checkForDeprecations(IntegrationBase.groovy:124)
	at nebula.test.IntegrationBase$Trait$Helper.checkOutput(IntegrationBase.groovy:89)
	at nebula.test.Integration$Trait$Helper.runTasks(Integration.groovy:167)
	at nebula.test.Integration$Trait$Helper.runTasksSuccessfully(Integration.groovy:148)
	at wooga.gradle.release.ReleasePluginIntegrationSpec.writes release notes for release description (ReleasePluginIntegrationSpec.groovy:429)
```